### PR TITLE
rename karma-bro to karma-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "expect.js": "^0.3.1",
     "jasmine-react-helpers": "^0.2.0",
     "karma": "^0.12.21",
-    "karma-bro": "^0.6.2",
+    "karma-browserify": "^1.0.0",
     "karma-chrome-launcher": "^0.1.4",
     "karma-cli": "0.0.4",
     "karma-firefox-launcher": "^0.1.3",


### PR DESCRIPTION
Old node module name "karma-bro" caused build error.
So, Renaming "karma-bro" to '"karma-browserify".

See. #54 npm install failed.

npm log say

``` console
npm WARN deprecated karma-bro@0.6.2: Renamed karma-browserify as of 1.0
```

and failed to build.

``` console
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make: *** [Release/obj.target/fse/fsevents.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/srg/.nodebrew/node/v0.12.7/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1074:12)
gyp ERR! System Darwin 14.4.0
gyp ERR! command "node" "/Users/srg/.nodebrew/node/v0.12.7/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/srg/dev/me/bleeding-edge-sample-app/node_modules/karma-bro/node_modules/watchify/node_modules/chokidar/node_modules/fsevents
gyp ERR! node -v v0.12.7
gyp ERR! node-gyp -v v2.0.1
gyp ERR! not ok 
npm WARN prefer global react-tools@0.11.2 should be installed with -g
```

Thank you.
